### PR TITLE
Update material_and_questions.md

### DIFF
--- a/content/rule_book/material_and_questions.md
+++ b/content/rule_book/material_and_questions.md
@@ -108,12 +108,6 @@ The question "Who is anything?" would require the answer:
 
 This is an invalid MA.
 
-Consider 1 Corinthians 9:25:
-
-> Everyone who competes in the games goes into strict training. They do it to get a crown that will not last, but we do it to get a crown that will last forever.
-
-The question "A crown that will what?" with an answer "Not last; last forever" is an invalid MA.
-
 #### Reference
 
 Reference question type group questions are used to distinguish between exact duplicate words or phrases from the material. The entire reference question is part of the required question and answer.


### PR DESCRIPTION
The exclusion of all negative answers from MA question types, I think, is an overreaction to the fact that sometimes a negative answer does not answer the question and should not be valid. Even the second example given in the rulebook (which I propose deleting) should be a valid MA question - "A crown that will not last" is a type of crown defined by its temporary character even as "a crown that will last forever" is defined by its eternal character. These are two different crowns. Also, this rule also makes Romans 8:38-39, one of the great Scripture verses about the love and power of God, unuseable as an MA ("What will be able to separate us from the love of God that is in Christ Jesus our Lord?"), which is the only way it could make it into the question set other than as a Quote or FTV. Again, I think this is a rule that overreaches in that it is attempting to correct a situation for some verses that someone might pull as an MA by eliminating all - even good - negative answers from the question pool of MAs. Whether a negative answer is valid or invalid needs to be reviewed on a case-by-case basis, meaning, is the answer to the question actually two or more different nouns, adjectives, or adverbs that would answer the interrogative.